### PR TITLE
Replace hardcoded WIX path with env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ WixDir	= $(BldDir)/wix
 Status	= $(BldDir)/status
 BinExtra= ssh #bash ls mount
 
-export PATH := /cygdrive/c/Program Files (x86)/WiX Toolset v3.10/bin:$(PATH)
+export PATH := $(WIX)/bin:$(PATH)
 
 goal: $(Status) $(Status)/done
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ WixDir	= $(BldDir)/wix
 Status	= $(BldDir)/status
 BinExtra= ssh #bash ls mount
 
-export PATH := $(WIX)/bin:$(PATH)
+export PATH := $(shell cygpath -au "$$WIX")/bin:$(PATH)
 
 goal: $(Status) $(Status)/done
 


### PR DESCRIPTION
WIX seems to always set system environment variable $WIX which points to its install location.
Build process won't be bound to specific version of the toolkit anymore