### PR TITLE
Add \\sshfs.key option to authenticate with ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The complete UNC syntax is as follows:
 
     \\sshfs\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
     \\sshfs.r\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
+    \\sshfs.key\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
 
 - `REMUSER` is the remote user (i.e. the user on the SSHFS host whose credentials are being used for access).
 - `HOST` is the SSHFS host.
@@ -88,6 +89,7 @@ The complete UNC syntax is as follows:
 - `PATH` is the remote path. This is interpretted as follows:
     - The `sshfs` prefix maps to `HOST:~REMUSER/PATH` on the SSHFS host (i.e. relative to `REMUSER`'s home directory).
     - The `sshfs.r` prefix maps to `HOST:/PATH` on the SSHFS host (i.e. relative to the `HOST`'s root directory).
+    - The `sshfs.key` prefix maps to `HOST:~REMUSER/PATH` and use the ssh key in %USERPROFILE%/.ssh/id_rsa, where %USERPROFILE% correspond to the windows home directory of the user.
 - `LOCUSER` is the local Windows user (optional; `USERNAME` or `DOMAIN+USERNAME` format).
     - Please note that this functionality is rarely necessary with latest versions of WinFsp.
 
@@ -114,7 +116,7 @@ usage: sshfs-win cmd SSHFS_COMMAND_LINE
 
 usage: sshfs-win svc PREFIX X: [LOCUSER] [SSHFS_OPTIONS]
     PREFIX              Windows UNC prefix (note single backslash)
-                        \sshfs[.r]\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
+                        \sshfs[.r|.key]\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
                         sshfs: remote home; sshfs.r: remote root
     LOCUSER             local user (DOMAIN+USERNAME)
     REMUSER             remote user

--- a/sshfs-win.wxs
+++ b/sshfs-win.wxs
@@ -130,6 +130,36 @@
                     </RegistryKey>
                 </RegistryKey>
             </Component>
+            <Component Id="C.sshfs.key.reg" Guid="{F8E1A2DE-2061-42AD-805F-33BF0F75DC36}">
+                <RegistryKey
+                    Root="HKLM"
+                    Key="[P.LauncherRegistryKey]">
+                    <RegistryKey
+                        Key="sshfs.key">
+                        <RegistryValue
+                            Type="string"
+                            Name="Executable"
+                            Value="[INSTALLDIR]bin\sshfs-win.exe"
+                            KeyPath="yes" />
+                        <RegistryValue
+                            Type="string"
+                            Name="CommandLine"
+                            Value="svc %1 %2 %U" />
+                        <RegistryValue
+                            Type="string"
+                            Name="Security"
+                            Value="D:P(A;;RPWPLC;;;WD)" />
+                        <RegistryValue
+                            Type="integer"
+                            Name="JobControl"
+                            Value="1" />
+                        <RegistryValue
+                            Type="integer"
+                            Name="Credentials"
+                            Value="0" />
+                    </RegistryKey>
+                </RegistryKey>
+            </Component>
         </DirectoryRef>
 
         <Feature
@@ -145,6 +175,7 @@
             <ComponentRef Id="C.INSTALLDIR" />
             <ComponentRef Id="C.sshfs.reg" />
             <ComponentRef Id="C.sshfs.r.reg" />
+            <ComponentRef Id="C.sshfs.key.reg" />
             <ComponentGroupRef Id="C.Main" />
         </Feature>
 


### PR DESCRIPTION
- Add a function that verify if the registry key is set to do the authentication with a password or without it.
- Pass PasswordAuthentication=0 and IdentityFile path to &lt;home&gt;/.ssh/id_rsa if the registry key is 0, otherwise pass password_stdin and password_stdout to sshfs.
- Add the registry key sshfs.key with Credentials = 0.