### PR TITLE
Add double quotes around the path to the ssh key

### DIFF
--- a/sshfs-win.c
+++ b/sshfs-win.c
@@ -201,7 +201,7 @@ static int do_svc(int argc, char *argv[])
             "-opassword_stdin,password_stdout");
     else if (0 != passwd)
         snprintf(authmeth, sizeof authmeth,
-            "-oPreferredAuthentications=publickey,IdentityFile=%s/.ssh/id_rsa", passwd->pw_dir);
+            "-oPreferredAuthentications=publickey,IdentityFile=\"%s/.ssh/id_rsa\"", passwd->pw_dir);
     else
         snprintf(authmeth, sizeof authmeth,
             "-oPreferredAuthentications=publickey");


### PR DESCRIPTION
Because in my Windows username I have a space, I got this error with the .k option :
```
$> sshfs-win.exe svc \sshfs.k\dcourcel@<domain name>!<port>\<folder> X: "<machine name>\<username with space>"
command-line line 0: garbage at end of line; "Courcelles/.ssh/id_rsa".
read: Connection reset by peer
```
I suggest to add double quotes around the IdentityFile value to avoid the error.