### PR TITLE
Allow to specify both .r and .k options in UNC path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The complete UNC syntax is as follows:
     \\sshfs\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
     \\sshfs.r\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
     \\sshfs.k\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
+    \\sshfs.r.k\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
 
 - `REMUSER` is the remote user (i.e. the user on the SSHFS host whose credentials are being used for access).
 - `HOST` is the SSHFS host.
@@ -90,6 +91,7 @@ The complete UNC syntax is as follows:
     - The `sshfs` prefix maps to `HOST:~REMUSER/PATH` on the SSHFS host (i.e. relative to `REMUSER`'s home directory).
     - The `sshfs.r` prefix maps to `HOST:/PATH` on the SSHFS host (i.e. relative to the `HOST`'s root directory).
     - The `sshfs.k` prefix maps to `HOST:~REMUSER/PATH` and uses the ssh key in `%USERPROFILE%/.ssh/id_rsa` (where `%USERPROFILE%` is the home directory of the local Windows user).
+    - The `sshfs.r.k` prefix maps to `HOST:/PATH` and uses the ssh key in `%USERPROFILE%/.ssh/id_rsa` (where `%USERPROFILE%` is the home directory of the local Windows user).
 - `LOCUSER` is the local Windows user (optional; `USERNAME` or `DOMAIN+USERNAME` format).
     - Please note that this functionality is rarely necessary with latest versions of WinFsp.
 
@@ -115,7 +117,7 @@ usage: sshfs-win cmd SSHFS_COMMAND_LINE
 
 usage: sshfs-win svc PREFIX X: [LOCUSER] [SSHFS_OPTIONS]
     PREFIX              Windows UNC prefix (note single backslash)
-                        \sshfs[.r|.k]\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
+                        \sshfs[.r][.k]\[LOCUSER=]REMUSER@HOST[!PORT][\PATH]
                         sshfs: remote home; sshfs.r: remote root
                         sshfs.k: remote home with key authentication
     LOCUSER             local user (DOMAIN+USERNAME)

--- a/sshfs-win.wxs
+++ b/sshfs-win.wxs
@@ -160,6 +160,36 @@
                     </RegistryKey>
                 </RegistryKey>
             </Component>
+            <Component Id="C.sshfs.r.k.reg" Guid="{F8E1A2DE-2061-42AD-805F-33BF0F75DC37}">
+                <RegistryKey
+                    Root="HKLM"
+                    Key="[P.LauncherRegistryKey]">
+                    <RegistryKey
+                        Key="sshfs.r.k">
+                        <RegistryValue
+                            Type="string"
+                            Name="Executable"
+                            Value="[INSTALLDIR]bin\sshfs-win.exe"
+                            KeyPath="yes" />
+                        <RegistryValue
+                            Type="string"
+                            Name="CommandLine"
+                            Value="svc %1 %2 %U" />
+                        <RegistryValue
+                            Type="string"
+                            Name="Security"
+                            Value="D:P(A;;RPWPLC;;;WD)" />
+                        <RegistryValue
+                            Type="integer"
+                            Name="JobControl"
+                            Value="1" />
+                        <RegistryValue
+                            Type="integer"
+                            Name="Credentials"
+                            Value="0" />
+                    </RegistryKey>
+                </RegistryKey>
+            </Component>
         </DirectoryRef>
 
         <Feature
@@ -176,6 +206,7 @@
             <ComponentRef Id="C.sshfs.reg" />
             <ComponentRef Id="C.sshfs.r.reg" />
             <ComponentRef Id="C.sshfs.k.reg" />
+            <ComponentRef Id="C.sshfs.r.k.reg" />
             <ComponentGroupRef Id="C.Main" />
         </Feature>
 


### PR DESCRIPTION
This is a suggestion to resolve #137 
- Create a structure to contain the different options that can be put inside UNC path. The structure would allow to add other options more easily  in the future.
- Add two functions : _parse_segment_ and _determine_option_. _parse_segment_ extract _sshfs_ characters and the different options. _determine_option_ modify the structure if the option is recognized.
- Add the registry key sshfs.r.k.
- Modify README.md file to indicate that sshfs.r.k can be used.