### PR TITLE
Build documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(Status)/config: $(Status)/patch
 	touch $(Status)/config
 
 $(Status)/patch: $(Status)/clone
-	cd $(SrcDir)/sshfs && for f in $(PrjDir)/patches/*.patch; do patch -p1 <$$f; done
+	cd $(SrcDir)/sshfs && for f in $(PrjDir)/patches/*.patch; do patch --binary -p1 <$$f; done
 	touch $(Status)/patch
 
 $(Status)/clone:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ $ sh WINFSP_INSTALL_DIR/opt/cygfuse/install.sh
 FUSE for Cygwin installed.
 ```
 
+## Building
+
+To build, run `make` in a Cygwin environment, with the following packages installed (e.g. by the Cygwin installation program):
+* git
+* meson
+* patch
+* libglib2.0-devel
+
+Also install:
+* FUSE for Cygwin (see above how to do this)
+* in your regular Windows environment: Wix Toolset, so that it can be found by Cygwin
+
+
 ## Project Organization
 
 This is a simple project:


### PR DESCRIPTION
I have just tried to build sshfs-win on my Windows machine (using Cygwin, since I assumed it is the expected way to do so).

I added little documentation that I wished I had before I built it.
I also added a `--binary` flag to `patch` in the Makefile. It turned out it worked this way on my machine, but maybe this depends on how anyone configures his line endings. Please review this commit and tell me what you think about it. Otherwise, I could add something like "try without this flag first, then with this flag if the former fails"