### PR TITLE
Rsync instead of clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(Status)/config: $(Status)/patch
 	touch $(Status)/config
 
 $(Status)/patch: $(Status)/clone
-	cd $(SrcDir)/sshfs && for f in $(PrjDir)/patches/*.patch; do patch -p1 <$$f; done
+	cd $(SrcDir)/sshfs && for f in $(PrjDir)/patches/*.patch; do patch --binary -p1 <$$f; done
 	touch $(Status)/patch
 
 $(Status)/clone:

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ $(Status)/patch: $(Status)/clone
 
 $(Status)/clone:
 	mkdir -p $(SrcDir)
-	git clone $(PrjDir)/sshfs $(SrcDir)/sshfs
+	rsync -ar $(PrjDir)/sshfs $(SrcDir)/
 	touch $(Status)/clone
 
 clean:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ $ sh WINFSP_INSTALL_DIR/opt/cygfuse/install.sh
 FUSE for Cygwin installed.
 ```
 
+## Building
+
+To build, run `make` in a Cygwin environment, with the following packages installed (e.g. by the Cygwin installation program):
+* git
+* meson
+* patch
+* libglib2.0-devel
+
+Also install:
+* FUSE for Cygwin (see above how to do this)
+* in your regular Windows environment: Wix Toolset, so that it can be found by Cygwin
+
+
 ## Project Organization
 
 This is a simple project:

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ FUSE for Cygwin installed.
 
 To build, run `make` in a Cygwin environment, with the following packages installed (e.g. by the Cygwin installation program):
 * git
+* rsync
 * meson
 * patch
 * libglib2.0-devel


### PR DESCRIPTION
This PR only adds a commit on top of the (already-existing) `daladim:build_documentation` PR.
I have created a distinct PR since I am sure this commit is really sensible, please review it and tell me what you think about it.

The provided `Makefile` would not work on my Cygwin installation. For some reason, using `git clone` from the `sshfs` submodule does not work (although it does on WSL). Replacing it with `rsync` works correctly.

Here is the error I had:
```
$ make
mkdir -p .build/x64/src
git clone /tmp/sshfs-win/sshfs .build/x64/src/sshfs
fatal: repository '/tmp/sshfs-win/sshfs' does not exist
make: *** [Makefile:99 : .build/x64/status/clone] Error 128
```