### PR TITLE
Checking for quotes around non-ascii usernames passed by Windows

### DIFF
--- a/sshfs-win.c
+++ b/sshfs-win.c
@@ -192,8 +192,13 @@ static int do_svc(int argc, char *argv[])
         }
         else
         {
-            /* translate backslash to '+' */
             locuser = argv[3];
+            /* Windows surrounds non-ascii usernames with quotes before passing them to sshfs-win */
+            if (locuser[0] == '"'){
+                ++locuser;                         /* remove the heading quote... */
+                locuser[strlen(locuser)-1] = 0;    /* ...and the trailing one     */
+            }
+            /* translate backslash to '+' */
             for (p = locuser; *p; p++)
                 if ('\\' == *p)
                 {

--- a/sshfs-win.c
+++ b/sshfs-win.c
@@ -193,10 +193,15 @@ static int do_svc(int argc, char *argv[])
         else
         {
             locuser = argv[3];
-            /* Windows surrounds non-ascii usernames with quotes before passing them to sshfs-win */
-            if (locuser[0] == '"'){
-                ++locuser;                         /* remove the heading quote... */
-                locuser[strlen(locuser)-1] = 0;    /* ...and the trailing one     */
+            /* the Cygwin runtime does not remove double quotes around args with non-ASCII chars */
+            if (locuser[0] == '"')
+            {
+                size_t len = strlen(locuser);
+                if (len >= 2 && locuser[len - 1] == '"')
+                {
+                    locuser[len - 1] = '\0';    /* remove the trailing quote... */
+                    ++locuser;                  /* ...and the heading one       */
+                }
             }
             /* translate backslash to '+' */
             for (p = locuser; *p; p++)


### PR DESCRIPTION
This pull request fixes issue #168 

When adding a network drive from the Explorer menu, Windows calls `sshfs-win` with the username as the 4th argument. When the username has non-ascii characters (e.g. `Jérôme`), Windows encodes it at UTF-8 and surrounds this username with quotes (thus, the 4th argument becomes `"Domain\Jérôme"`). When sshfs-win tries to turn this username-and-quotes into a uid/gid, it (expectedly) fails.
In the end, it does not correctly populates the permissions of the files and folders and makes the network disk read-only.

Coming from the Linux world, I am not accustomed enough to Windows yet to decide whether this behaviour is expected, and whether `sshfs-win` should cope with this, or whether Windows itself (or WinFsp?) should be told not to add quotes around a non-acii parameter.
In case it was `sshfs-win`'s duty to check it, I have done it in this PR, which fixes the issue I had opened a few weeks ago.