### PR TITLE
Remove default ssh port

### DIFF
--- a/sshfs-win.c
+++ b/sshfs-win.c
@@ -321,9 +321,12 @@ static int do_svc(int argc, char *argv[])
         sshfs, SSHFS_ARGS, idmap, authmeth, volpfx, portopt, remote, argv[2], 0,
     };
 
-    if (strlen(portopt) == 0)
+    if ('\0' == portopt[0])
     {
-        int portopt_idx = 10;
+        /* if not passing a port option, remove it from sshfs_argv */
+        int portopt_idx = 0;
+        while (sshfs_argv[portopt_idx] != portopt)
+            portopt_idx++;
         while (sshfs_argv[portopt_idx] != 0)
         {
             sshfs_argv[portopt_idx] = sshfs_argv[portopt_idx + 1];


### PR DESCRIPTION
Port is not a must option for `ssfhs.exe`.

If `-oPort=1234` is passed, `sshfs.exe` will pass `-Port=1234` to `ssh.exe`.  
If nothing is passed, `sshfs.exe` will pass nothing to `ssh.exe`.

The bug is: current code always force use `-oPort=22` even if user doesn't assign any port.

```
    port = "22";
```

When port is assigned in `alias` and the port is not 22, `ssh.exe` should connect to custom port in `alias` rather than 22.