### PR TITLE
Simplify suggested winget command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ SSHFS-Win is a minimal port of [SSHFS](https://github.com/libfuse/sshfs) to Wind
 Both can also be easily installed with [WinGet](https://github.com/microsoft/winget-cli):
 
 ```console
-winget install -h -e --id "WinFsp.WinFsp" ; winget install -h -e --id "SSHFS-Win.SSHFS-Win"
+winget install SSHFS-Win.SSHFS-Win
 ```
 
 ## Basic Usage


### PR DESCRIPTION
- `-h` just makes it silent, it's unnecessary
- nowadays winget automatically handle installation dependencies (winfsp)
  - https://github.com/microsoft/winget-pkgs/blob/70d56db3eeb0ad334e2b672b56cce689df92a642/manifests/s/SSHFS-Win/SSHFS-Win/3.5.20357/SSHFS-Win.SSHFS-Win.installer.yaml#L13
- `-e --id` is unnecessary because winget already gives max preference for an exact match of the id by default