### PR TITLE
Windows native OpenSSH fix

### DIFF
--- a/patches/30-stdiomode.patch
+++ b/patches/30-stdiomode.patch
@@ -1,0 +1,34 @@
+From d78a624756d080c80a35886ba3615e809bbdb56b Mon Sep 17 00:00:00 2001
+From: Emmanuel Dreyfus <manu@netbsd.org>
+Date: Wed, 20 Nov 2024 16:00:40 +0100
+Subject: [PATCH] Windows native OpenSSH fix
+
+Windows native OpenSSH has alternative behavior for standard I/O
+descriptors, which can be selected through the OPENSSH_STDIO_MODE
+environement variable. Setting it to "nonsock" is required for
+sshfs compatibility.
+
+See https://github.com/PowerShell/openssh-portable/pull/759
+for details.
+---
+ sshfs.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/sshfs.c b/sshfs.c
+index 89c57606..809568ad 100644
+--- a/sshfs.c
++++ b/sshfs.c
+@@ -1227,6 +1227,13 @@ static int start_ssh(struct conn *conn)
+ 			fprintf(stderr, "\n");
+ 		}
+ 
++#if defined(__CYGWIN__)
++		/* 
++		 * Windows native OpenSSH stdio behavior. For details check
++		 * https://github.com/PowerShell/openssh-portable/pull/759
++		 */
++		putenv("OPENSSH_STDIO_MODE=nonsock");
++#endif
+ 		execvp(sshfs.ssh_args.argv[0], sshfs.ssh_args.argv);
+ 		fprintf(stderr, "failed to execute '%s': %s\n",
+ 			sshfs.ssh_args.argv[0], strerror(errno));


### PR DESCRIPTION
Windows native OpenSSH has alternative behavior for standard I/O descriptors, which can be selected through the OPENSSH_STDIO_MODE environement variable. Setting it to "nonsock" is required for sshfs compatibility.

See https://github.com/PowerShell/openssh-portable/pull/759 for details.

Subitted upstream here
https://github.com/libfuse/sshfs/pull/314